### PR TITLE
26th April pull request

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,6 +55,8 @@ jobs:
 
     - name: Run example tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
+      env:
+        SPARK_LOCAL_IP: 127.0.0.1
       run: |
         source activate test-environment
         pytest --verbose tests/examples --durations=30 --large

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -184,6 +184,21 @@ jobs:
         export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         ./dev/run-large-python-tests.sh
+    - name: Run database initialization tests
+      run: |
+        set -x
+        # Build wheel and copy it under tests/db
+        python setup.py bdist_wheel
+        cp -r dist tests/db
+
+        # Run tests
+        cd tests/db
+        docker-compose build
+        docker-compose run mlflow-postgres python log.py
+        docker-compose run mlflow-mysql python log.py
+
+        # Clean up
+        docker-compose down --rmi all --volumes
     - name: Run anaconda compatibility tests
       run: |
         ./dev/test-anaconda-compatibility.sh "anaconda3:2020.11"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,24 @@
 Changelog
 =========
+1.16.0 (2021-04-22)
+-------------------
+MLflow 1.16.0 includes several major features and improvements:
+
+Features:
+
+- Add ``mlflow.pyspark.ml.autolog()`` API for autologging of ``pyspark.ml`` estimators (#4228, @WeichenXu123)
+- Add ``mlflow.catboost.log_model``, ``mlflow.catboost.save_model``, ``mlflow.catboost.load_model`` APIs for CatBoost model persistence (#2417, @harupy)
+- Enable ``mlflow.pyfunc.spark_udf`` to use column names from model signature by default (#4236, @Loquats)
+- Add ``datetime`` data type for model signatures (#4241, @vperiyasamy)
+- Add ``mlflow.sklearn.eval_and_log_metrics`` API that computes and logs metrics for the given scikit-learn model and labeled dataset. (#4218, @alkispoly-db)
+
+Bug fixes and documentation updates:
+
+- Fix a database migration error for PostgreSQL (#4211, @dolfinus)
+- Fix autologging silent mode bugs (#4231, @dbczumar)
+
+Small bug fixes and doc updates (#4255, #4252, #4254, #4253, #4242, #4247, #4243, #4237, #4233, @harupy; #4225, @dmatrix; #4206, @mlflow-automation; #4207, @shrinath-suresh; #4264, @WeichenXu123; #3884, #3866, #3885, @ankan94; #4274, #4216, @dbczumar)
+
 1.15.0 (2021-03-26)
 -------------------
 MLflow 1.15.0 includes several features, bug fixes and improvements. Notably, it includes a number of improvements to MLflow autologging:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -403,15 +403,23 @@ def expand_config(config):
             if cfg["minimum"] not in versions:
                 versions.append(cfg["minimum"])
 
+            pip_release = package_info["pip_release"]
             for ver in versions:
                 job_name = " / ".join([flavor_key, ver, key])
-                requirements = ["{}=={}".format(package_info["pip_release"], ver)]
+                requirements = ["{}=={}".format(pip_release, ver)]
                 requirements.extend(process_requirements(cfg.get("requirements"), ver))
                 install = make_pip_install_command(requirements)
                 run = remove_comments(cfg["run"])
 
                 matrix.append(
-                    Hashabledict(flavor=flavor, job_name=job_name, install=install, run=run,)
+                    Hashabledict(
+                        flavor=flavor,
+                        job_name=job_name,
+                        install=install,
+                        run=run,
+                        package=pip_release,
+                        version=ver,
+                    )
                 )
 
             # Development version
@@ -424,7 +432,14 @@ def expand_config(config):
                 run = remove_comments(cfg["run"])
 
                 matrix.append(
-                    Hashabledict(flavor=flavor, job_name=job_name, install=install, run=run,)
+                    Hashabledict(
+                        flavor=flavor,
+                        job_name=job_name,
+                        install=install,
+                        run=run,
+                        package=pip_release,
+                        version=ver,
+                    )
                 )
     return matrix
 

--- a/examples/pyspark_ml_autologging/README.md
+++ b/examples/pyspark_ml_autologging/README.md
@@ -1,0 +1,8 @@
+# PySpark ML Autologging Examples
+
+This directory contains examples for demonstrating how PySpark ML autologging works.
+
+| File                     | Description                        |
+| :----------------------- | :--------------------------------- |
+| `logistic_regression.py` | Train a `LogisticRegression` model |
+| `one_vs_rest.py`         | Train a `OneVsRest` model          |

--- a/examples/pyspark_ml_autologging/logistic_regression.py
+++ b/examples/pyspark_ml_autologging/logistic_regression.py
@@ -1,0 +1,24 @@
+from pyspark.ml.classification import LogisticRegression
+from pyspark.ml.feature import VectorAssembler
+from pyspark.sql import SparkSession
+from sklearn.datasets import load_iris
+
+import mlflow
+
+spark = SparkSession.builder.getOrCreate()
+
+df = load_iris(as_frame=True).frame.rename(columns={"target": "label"})
+df = spark.createDataFrame(df)
+df = VectorAssembler(inputCols=df.columns[:-1], outputCol="features").transform(df)
+train, test = df.randomSplit([0.8, 0.2])
+
+mlflow.pyspark.ml.autolog()
+lor = LogisticRegression(maxIter=5)
+
+with mlflow.start_run():
+    lorModel = lor.fit(train)
+
+pred = lorModel.transform(test)
+pred.select(lorModel.getPredictionCol()).show(10)
+
+spark.stop()

--- a/examples/pyspark_ml_autologging/one_vs_rest.py
+++ b/examples/pyspark_ml_autologging/one_vs_rest.py
@@ -1,0 +1,25 @@
+from pyspark.ml.classification import LogisticRegression, OneVsRest
+from pyspark.ml.feature import VectorAssembler
+from pyspark.sql import SparkSession
+from sklearn.datasets import load_iris
+
+import mlflow
+
+spark = SparkSession.builder.getOrCreate()
+
+df = load_iris(as_frame=True).frame.rename(columns={"target": "label"})
+df = spark.createDataFrame(df)
+df = VectorAssembler(inputCols=df.columns[:-1], outputCol="features").transform(df)
+train, test = df.randomSplit([0.8, 0.2])
+
+mlflow.pyspark.ml.autolog()
+lor = LogisticRegression(maxIter=5)
+ovr = OneVsRest(classifier=lor)
+
+with mlflow.start_run():
+    ovrModel = ovr.fit(train)
+
+pred = ovrModel.transform(test)
+pred.select(ovrModel.getPredictionCol()).show(10)
+
+spark.stop()

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -275,6 +275,17 @@ statsmodels:
 spark:
   package_info:
     pip_release: "pyspark"
+    install_dev: |
+      # TODO: Consider using cache because it takes long (20 ~ 30 min) to build spark from source
+      # on GitHub Actions environment.
+      temp_dir=$(mktemp -d)
+      git clone --depth 1 https://github.com/apache/spark $temp_dir
+      cd $temp_dir
+      export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g"
+      ./build/mvn -DskipTests --no-transfer-progress clean package
+      cd python
+      python setup.py bdist_wheel
+      pip install dist/*.whl
 
   models:
     minimum: "3.0.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -26,7 +26,7 @@ pytorch:
 
   models:
     minimum: "1.4.0"
-    maximum: "1.8.0"
+    maximum: "1.8.1"
     requirements: ["torchvision", "scikit-learn"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py --large
@@ -40,7 +40,7 @@ pytorch-lightning:
 
   autologging:
     minimum: "1.0.5"
-    maximum: "1.2.4"
+    maximum: "1.2.8"
     requirements: ["torchvision", "scikit-learn"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py --large
@@ -137,14 +137,14 @@ xgboost:
 
   models:
     minimum: "0.90"
-    maximum: "1.3.3"
+    maximum: "1.4.1"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/xgboost/test_xgboost_model_export.py --large
 
   autologging:
     minimum: "0.90"
-    maximum: "1.3.3"
+    maximum: "1.4.1"
     requirements: ["scikit-learn", "matplotlib"]
     run: |
       pytest tests/xgboost/test_xgboost_autolog.py --large
@@ -160,14 +160,14 @@ lightgbm:
 
   models:
     minimum: "2.3.1"
-    maximum: "3.2.0"
+    maximum: "3.2.1"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/lightgbm/test_lightgbm_model_export.py --large
 
   autologging:
     minimum: "2.3.1"
-    maximum: "3.2.0"
+    maximum: "3.2.1"
     requirements: ["scikit-learn", "matplotlib"]
     run: |
       pytest tests/lightgbm/test_lightgbm_autolog.py --large
@@ -193,14 +193,14 @@ gluon:
 
   models:
     minimum: "1.5.1"
-    maximum: "1.7.0.post2"
+    maximum: "1.8.0.post0"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
       pytest tests/gluon/test_gluon_model_export.py --large
 
   autologging:
     minimum: "1.5.1"
-    maximum: "1.7.0.post2"
+    maximum: "1.8.0.post0"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
       pytest tests/gluon_autolog/test_gluon_autolog.py --large
@@ -236,7 +236,7 @@ onnx:
 
   models:
     minimum: "1.5.0"
-    maximum: "1.8.1"
+    maximum: "1.9.0"
     requirements: ["onnxruntime", "torch", "scikit-learn"]
     run: |
       pytest tests/onnx/test_onnx_model_export.py --large

--- a/mlflow/pyspark/ml/log_model_allowlist.txt
+++ b/mlflow/pyspark/ml/log_model_allowlist.txt
@@ -39,3 +39,6 @@ pyspark.ml.feature.UnivariateFeatureSelectorModel
 
 # composite model
 pyspark.ml.classification.OneVsRestModel
+
+# pipeline model
+pyspark.ml.pipeline.PipelineModel

--- a/tests/db/.dockerignore
+++ b/tests/db/.dockerignore
@@ -1,0 +1,4 @@
+**
+
+!dist/*.whl
+!log.py

--- a/tests/db/Dockerfile
+++ b/tests/db/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.6
+
+WORKDIR /tmp/mlflow
+
+COPY dist ./dist
+
+RUN pip install dist/*.whl
+RUN pip install psycopg2 pymysql mysqlclient
+RUN pip list
+
+COPY log.py .

--- a/tests/db/docker-compose.yml
+++ b/tests/db/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3"
+services:
+  postgres:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: mlflowdb
+      POSTGRES_USER: mlflowuser
+      POSTGRES_PASSWORD: mlflowpassword
+
+  mlflow-postgres:
+    depends_on:
+      - postgres
+    build:
+      context: .
+    environment:
+      MLFLOW_TRACKING_URI: postgresql://mlflowuser:mlflowpassword@postgres:5432/mlflowdb
+
+  mysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root-password
+      MYSQL_DATABASE: mlflowdb
+      MYSQL_USER: mlflowuser
+      MYSQL_PASSWORD: mlflowpassword
+
+  mlflow-mysql:
+    depends_on:
+      - mysql
+    build:
+      context: .
+    environment:
+      MLFLOW_TRACKING_URI: mysql://mlflowuser:mlflowpassword@mysql:3306/mlflowdb

--- a/tests/db/log.py
+++ b/tests/db/log.py
@@ -1,0 +1,25 @@
+import os
+
+import mlflow
+from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
+
+assert _TRACKING_URI_ENV_VAR in os.environ
+
+
+class MockModel(mlflow.pyfunc.PythonModel):
+    def load_context(self, context):
+        pass
+
+    def predict(self, context, model_input):
+        pass
+
+
+with mlflow.start_run() as run:
+    print("Tracking URI:", mlflow.get_tracking_uri())
+    mlflow.log_param("p", "param")
+    mlflow.log_metric("m", 1.0)
+    mlflow.set_tag("t", "tag")
+    mlflow.pyfunc.log_model(
+        artifact_path="model", python_model=MockModel(), registered_model_name="mock",
+    )
+    print(mlflow.get_run(run.info.run_id))

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -172,6 +172,8 @@ def test_mlflow_run_example(directory, params, tmpdir):
         ("sklearn_autolog", ["python", "linear_regression.py"]),
         ("sklearn_autolog", ["python", "pipeline.py"]),
         ("sklearn_autolog", ["python", "grid_search_cv.py"]),
+        ("pyspark_ml_autologging", ["python", "logistic_regression.py"]),
+        ("pyspark_ml_autologging", ["python", "one_vs_rest.py"]),
         ("shap", ["python", "regression.py"]),
         ("shap", ["python", "binary_classification.py"]),
         ("shap", ["python", "multiclass_classification.py"]),

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -278,6 +278,10 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    "dev" in pyspark.__version__,
+    reason="The dev version of pyspark built from the source doesn't exist on PyPI or Anaconda",
+)
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
     sparkm.save_model(spark_model_iris.model, path=model_path, conda_env=None)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
verified changes of the last 3 days of pull
(Please fill in changes proposed in this fix)

## How is this patch tested?

this patch is community tested 

## Release Notes

refer to community

### Is this a user-facing change?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ x] `area/server-infra`: MLflow server, JavaScript dev server
- [x ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
