### PR TITLE
Implementing oath2's grant_type=client_credentials workflow.

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -990,6 +990,9 @@ allow passing HTTP authentication to the tracking server:
   of the ``requests.request`` function
   (see `requests main interface <https://requests.readthedocs.io/en/master/api/>`_).
   This can be used to use a (self-signed) client certificate.
+- ``OATH2_TOKEN_PROVIDER_URL`` , ``OATH2_CLIENT_ID``, ``OATH2_CLIENT_SECRET`` and ``OATH2_TOKEN_SCOPE`` - To use the
+  oath2's `client_credentials` workflow implemented by providers like google, azure etc you should set `all the variables`
+  For more info refer to `RFC 6749 <https://tools.ietf.org/html/rfc6749#section-1.3.4>`_
 
 
 .. note::

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -28,6 +28,13 @@ _TRACKING_SERVER_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_SERVER_CERT_PATH"
 # see https://requests.readthedocs.io/en/master/api/
 _TRACKING_CLIENT_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_CLIENT_CERT_PATH"
 
+# sets the param required for oath2 implementation, specifically client_credentials
+# [RFC 6749] https://tools.ietf.org/html/rfc6749#section-1.3.4
+_TRACKING_TOKEN_PROVIDER_URL_ENV_VAR = "OATH2_TOKEN_PROVIDER_URL"
+_TRACKING_CLIENT_ID_ENV_VAR = "OATH2_CLIENT_ID"
+_TRACKING_CLIENT_SECRET_ENV_VAR = "OATH2_CLIENT_SECRET"
+_TRACKING_TOKEN_SCOPE_ENV_VAR = "OATH2_TOKEN_SCOPE"
+
 _tracking_uri = None
 
 
@@ -126,6 +133,10 @@ def _get_default_host_creds(store_uri):
         ignore_tls_verification=os.environ.get(_TRACKING_INSECURE_TLS_ENV_VAR) == "true",
         client_cert_path=os.environ.get(_TRACKING_CLIENT_CERT_PATH_ENV_VAR),
         server_cert_path=os.environ.get(_TRACKING_SERVER_CERT_PATH_ENV_VAR),
+        token_url=os.environ.get(_TRACKING_TOKEN_PROVIDER_URL_ENV_VAR),
+        client_id=os.environ.get(_TRACKING_CLIENT_ID_ENV_VAR),
+        client_secret=os.environ.get(_TRACKING_CLIENT_SECRET_ENV_VAR),
+        token_scope=os.environ.get(_TRACKING_TOKEN_SCOPE_ENV_VAR),
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ SKINNY_REQUIREMENTS = [
     "protobuf>=3.6.0",
     "pytz",
     "requests>=2.17.3",
+    "requests-oauthlib>=1.3.0",
+    "oauthlib>=1.3.0",
 ]
 
 """

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -15,6 +15,7 @@ from mlflow.utils.rest_utils import (
 )
 from mlflow.protos.service_pb2 import GetRun
 from tests import helper_functions
+from requests_oauthlib.oauth2_session import OAuth2Session
 
 
 def test_well_formed_json_error_response():
@@ -151,6 +152,28 @@ def test_http_request_server_cert_path(request):
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
         url="http://my-host/my/endpoint", verify="/some/path", headers=_DEFAULT_HEADERS,
+    )
+
+
+@mock.patch.object(OAuth2Session, "fetch_token")
+@mock.patch("requests.request")
+def test_http_request_token_from_oath2_provider_url(request, fetch_token_mock):
+    fetch_token_mock.return_value = {"access_token": "my-token"}
+    host_only = MlflowHostCreds(
+        "https://my-host",
+        token_url="https://token-provider/oauth2/v2.0/token",
+        client_id="myclient",
+        client_secret="myclient-secret",
+        token_scope="myclient/.default",
+    )
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    http_request(host_only, "/my/endpoint")
+    headers = dict(_DEFAULT_HEADERS)
+    headers["Authorization"] = "Bearer my-token"
+    request.assert_called_with(
+        url="https://my-host/my/endpoint", verify=True, headers=headers,
     )
 
 


### PR DESCRIPTION
Signed-off-by: aash <aash@monsanto.com>

## What changes are proposed in this pull request?

The current implementation supports basic password and token based authentication. A more popular frame work is the oath2 flow, the current change request implements only the client_credentials flow. Welcome other contributors

## How is this patch tested?

Patch is tested locally.

## Release Notes

Implementing Oath2 grant_type=client_credentials 

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ x ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ x ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
