### PR TITLE
Syncing the 1.17 version changes

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -990,6 +990,17 @@ allow passing HTTP authentication to the tracking server:
   of the ``requests.request`` function
   (see `requests main interface <https://requests.readthedocs.io/en/master/api/>`_).
   This can be used to use a (self-signed) client certificate.
+- ``MLFLOW_OATH2_KWARGS`` - To use the oath2's workflow implemented by providers like google, azure etc you should set
+  `variables` that query the `OAuth2Session library <https://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html#backend-application-flow>`_
+
+  example: list experiments (fronted by oath2 provider accepting client_credentials)
+
+.. code-block:: bash
+
+  export MLFLOW_OATH2_KWARGS='{"client_id":"abcd","client_secret": "f3_vB~y","token_url": "https://login.microsoftonline.com/abcd/oauth2/v2.0/token","scope": "abcd/.default"}'
+  export MLFLOW_TRACKING_URI=https://api-np.science-at-scale.io/mlflow-np
+
+  mlflow experiments list
 
 
 .. note::

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -8,6 +8,7 @@ from mlflow.tracking._tracking_service.utils import (
     _TRACKING_PASSWORD_ENV_VAR,
     _TRACKING_TOKEN_ENV_VAR,
     _TRACKING_INSECURE_TLS_ENV_VAR,
+    _TRACKING_OATH2_KWARGS_VAR,
     _resolve_tracking_uri,
     get_tracking_uri,
 )
@@ -127,6 +128,7 @@ def _get_rest_store(store_uri, **_):
             password=os.environ.get(_TRACKING_PASSWORD_ENV_VAR),
             token=os.environ.get(_TRACKING_TOKEN_ENV_VAR),
             ignore_tls_verification=os.environ.get(_TRACKING_INSECURE_TLS_ENV_VAR) == "true",
+            oath_kwargs=os.environ.get(_TRACKING_OATH2_KWARGS_VAR),
         )
 
     return RestStore(get_default_host_creds)

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -28,6 +28,10 @@ _TRACKING_SERVER_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_SERVER_CERT_PATH"
 # see https://requests.readthedocs.io/en/master/api/
 _TRACKING_CLIENT_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_CLIENT_CERT_PATH"
 
+# sets the param required for oath2 implementation, specifically client_credentials
+# [RFC 6749] https://tools.ietf.org/html/rfc6749#section-1.3.4
+_TRACKING_OATH2_KWARGS_VAR = "MLFLOW_OATH2_KWARGS"
+
 _tracking_uri = None
 
 
@@ -126,6 +130,7 @@ def _get_default_host_creds(store_uri):
         ignore_tls_verification=os.environ.get(_TRACKING_INSECURE_TLS_ENV_VAR) == "true",
         client_cert_path=os.environ.get(_TRACKING_CLIENT_CERT_PATH_ENV_VAR),
         server_cert_path=os.environ.get(_TRACKING_SERVER_CERT_PATH_ENV_VAR),
+        oath_kwargs=os.environ.get(_TRACKING_OATH2_KWARGS_VAR),
     )
 
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -14,12 +14,31 @@ from mlflow.utils.proto_json_utils import parse_dict
 from mlflow.utils.string_utils import strip_suffix
 from mlflow.exceptions import MlflowException, RestException
 
+from requests_oauthlib import OAuth2Session
+from oauthlib.oauth2 import BackendApplicationClient
+
 _REST_API_PATH_PREFIX = "/api/2.0"
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
 
 _logger = logging.getLogger(__name__)
 
 _DEFAULT_HEADERS = {"User-Agent": "mlflow-python-client/%s" % __version__}
+
+
+def get_client_credentials(host):
+    """
+    Get bearer token from an oath provider.
+    :param host: object of class MlflowHostCreds
+    :return: token from oath endpoint
+    """
+    data = json.loads(host.oath_kwargs)
+    client = BackendApplicationClient(client_id=data["client_id"])
+    oauth = OAuth2Session(client=client)
+    try:
+        token = oauth.fetch_token(**data)
+        return token.get("access_token")
+    except (requests.exceptions.HTTPError, requests.exceptions.Timeout):
+        return get_client_credentials(host)
 
 
 def http_request(
@@ -43,6 +62,8 @@ def http_request(
         auth_str = "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
     elif host_creds.token:
         auth_str = "Bearer %s" % host_creds.token
+    elif host_creds.oath_kwargs:
+        auth_str = "Bearer %s" % get_client_credentials(host_creds)
 
     from mlflow.tracking.request_header.registry import resolve_request_headers
 
@@ -264,6 +285,7 @@ class MlflowHostCreds(object):
         ignore_tls_verification=False,
         client_cert_path=None,
         server_cert_path=None,
+        oath_kwargs=None,
     ):
         if not host:
             raise MlflowException(
@@ -288,3 +310,4 @@ class MlflowHostCreds(object):
         self.ignore_tls_verification = ignore_tls_verification
         self.client_cert_path = client_cert_path
         self.server_cert_path = server_cert_path
+        self.oath_kwargs = oath_kwargs

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ SKINNY_REQUIREMENTS = [
     "protobuf>=3.6.0",
     "pytz",
     "requests>=2.17.3",
+    "requests-oauthlib>=1.3.0",
+    "oauthlib>=1.3.0",
 ]
 
 """


### PR DESCRIPTION
## What changes are proposed in this pull request?

Syncing the 1.17 version changes

## How is this patch tested?

yes


## Release Notes
Syncing the 1.17 version changes

### Is this a user-facing change?

- [ x ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ x ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ x ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
